### PR TITLE
Added Swansea University Computer Society link

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     <li><a href="http://hacksoc.org">York HackSoc</a></li>
     <li><a href="https://github.com/NapierDevSoc">Napier University Developers Society</a></li>
     <li><a href="http://www.gutechsoc.com/">Glasgow University Tech Society</a></li>
+    <li><a href="https://sucs.org">Swansea University Computer Society</a></li>
   </ul>
 
   <h3>Future plans</h3>


### PR DESCRIPTION
Added Swansea University Computer Society (SUCS) to the links on the homepage.
