### PR TITLE
Modify Napier to use New Domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <li><a href="http://comp-soc.com">Edinburgh CompSoc</a></li>
     <li><a href="http://www.gutechsoc.com/">Glasgow University Tech Society</a></li>
     <li><a href="http://www.kcltech.com">King's College London Tech Society</a></li>
-    <li><a href="https://github.com/NapierDevSoc">Napier University Developers Society</a></li>
+    <li><a href="http://napierdevsoc.uk/">Napier University Developers Society</a></li>
     <li><a href="http://www.uoncompsoc.org.uk/">Compsoc Nottingham</a></li>
     <li><a href="http://hacksocnotts.co.uk/">Hacksoc Nottingham</a></li>
     <li><a href="http://ox.compsoc.net">Oxford CompSoc</a></li>


### PR DESCRIPTION
I've updated Napier's link from their github pages to their new domain (napierdevsoc.uk)
