### PR TITLE
Upgrade to Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+collections:
+- societies

--- a/_data/societies.yml
+++ b/_data/societies.yml
@@ -1,0 +1,54 @@
+- title: Strathclyde Tech Society
+  url: http://www.strathtech.co.uk/
+  city: Glasgow
+  university: Strathclyde
+
+- title: Edinburgh CompSoc
+  url: http://comp-soc.com
+  city: Edinburgh
+  university: Edinburgh
+
+- title: Glasgow University Tech Society
+  url: http://www.gutechsoc.com/
+  city: Glasgow
+  university: Glasgow
+
+- title: King's College London Tech Society
+  url: http://www.kcltech.com
+  city: London
+  university: King's College London
+
+- title: Napier University Developers Society
+  url: http://napierdevsoc.uk/
+  city: Edinburgh
+  university: Napier
+
+- title: Compsoc Nottingham
+  url: http://www.uoncompsoc.org.uk/
+  city: Nottingham
+  university: Nottingham
+
+- title: Hacksoc Nottingham
+  url: http://hacksocnotts.co.uk/
+  city: Nottingham
+  university: Nottingham
+
+- title: Oxford CompSoc
+  url: http://ox.compsoc.net
+  city: Oxford
+  university: Oxford
+
+- title: Swansea University Computer Society
+  url: https://sucs.org
+  city: Swansea
+  university: Swansea
+
+- title: University of Warwick Computing Society
+  url: http://www.uwcs.co.uk
+  city: Warwick
+  university: Warwick
+
+- title: York HackSoc
+  url: http://hacksoc.org
+  city: York
+  university: York

--- a/index.md
+++ b/index.md
@@ -1,3 +1,5 @@
+---
+---
 <html>
 <head>
   <title>CompSocs UK</title>
@@ -23,7 +25,7 @@
   webchat</a> to connect to the channel.</p>
 
   <h3>Bot</h3>
-  
+
   <p>There is (at least one) utility bot in the channel. One of the
     functions it provides is intended to make it easy to check which
     university and society someone is from (as this question comes up
@@ -39,24 +41,18 @@
 
   <p>These societies have been seen in the channel:</p>
   <ul>
-    <li><a href="http://comp-soc.com">Edinburgh CompSoc</a></li>
-    <li><a href="http://www.gutechsoc.com/">Glasgow University Tech Society</a></li>
-    <li><a href="http://www.kcltech.com">King's College London Tech Society</a></li>
-    <li><a href="http://napierdevsoc.uk/">Napier University Developers Society</a></li>
-    <li><a href="http://www.uoncompsoc.org.uk/">Compsoc Nottingham</a></li>
-    <li><a href="http://hacksocnotts.co.uk/">Hacksoc Nottingham</a></li>
-    <li><a href="http://ox.compsoc.net">Oxford CompSoc</a></li>
-    <li><a href="http://geeksoc.org">Strathclyde GeekSoc</a></li>
-    <li><a href="https://sucs.org">Swansea University Computer Society</a></li>
-    <li><a href="http://www.uwcs.co.uk">University of Warwick Computing Society</a></li>
-    <li><a href="http://hacksoc.org">York HackSoc</a></li>
+    {% assign socs = site.data.societies | sort: 'university' %}
+    {% for society in socs %}
+    <li><a href="{{ society.url }}">{{ society.title }}</a></li>
+    {% endfor %}
+
   </ul>
 
   <h3>Future plans</h3>
   <p>Hopefully, various group activities will be organised among the
   people in <tt>#compsoc-uk</tt>. Perhaps when this becomes a proper
   website, those events will be listed here.</p>
-  
+
   <h3>This Website</h3>
 
   <p>If you'd like to improve this website, it is hosted on GitHub pages, in the repository
@@ -67,4 +63,3 @@
 
 </body>
 </html>
-


### PR DESCRIPTION
Upgraded the site to utilise the power of Jekyll
Renamed Strathclyde GeekSoc to Strathclyde Tech Soc (StrathTech)